### PR TITLE
CurationMarket: fix import name

### DIFF
--- a/contracts/CurationMarket.sol
+++ b/contracts/CurationMarket.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.18;
 
-import "zeppelin-solidity/contracts/ownership/ownable.sol";
+import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 import "bancor-contracts/solidity/contracts/converter/BancorFormula.sol";
 import "./ICloversController.sol";
 import "./IClovers.sol";


### PR DESCRIPTION
Previously when tried to run tests, those failed to start with:

```
Error: Could not find zeppelin-solidity/contracts/ownership/ownable.sol from any sources;
...
```

With this fix the tests run (fail currently, but at least run).